### PR TITLE
Translations update from ioBroker Translation System

### DIFF
--- a/www/i18n/de/translations.json
+++ b/www/i18n/de/translations.json
@@ -1288,7 +1288,7 @@
     "Visibility of background from BACKGROUND_URL/HTML, if device is enlarged": "Sichtbarkeit des Hintergrundes von BACKGROUND_URL/HTML, wenn das Gerät vergrößert ist",
     "Visibility of background from BACKGROUND_VIEW/URL/HTML, if device is enlarged": "Sichtbarkeit des Hintergrundes von BACKGROUND_VIEW/URL/HTML, wenn das Gerät vergrößert ist",
     "Visible": "Sichtbar",
-    "Volume": "Lautstärke",
+    "Volume": "Volumen",
     "Vorraum": "Vorraum",
     "WC EG": "WC EG",
     "WC OG": "WC OG",

--- a/www/i18n/de/translations.json
+++ b/www/i18n/de/translations.json
@@ -1288,7 +1288,7 @@
     "Visibility of background from BACKGROUND_URL/HTML, if device is enlarged": "Sichtbarkeit des Hintergrundes von BACKGROUND_URL/HTML, wenn das Gerät vergrößert ist",
     "Visibility of background from BACKGROUND_VIEW/URL/HTML, if device is enlarged": "Sichtbarkeit des Hintergrundes von BACKGROUND_VIEW/URL/HTML, wenn das Gerät vergrößert ist",
     "Visible": "Sichtbar",
-    "Volume": "Volumen",
+    "Volume": "Lautstärke",
     "Vorraum": "Vorraum",
     "WC EG": "WC EG",
     "WC OG": "WC OG",

--- a/www/i18n/fr/translations.json
+++ b/www/i18n/fr/translations.json
@@ -1288,7 +1288,7 @@
     "Visibility of background from BACKGROUND_URL/HTML, if device is enlarged": "Visibilité de l'arrière-plan à partir de BACKGROUND_URL / HTML, si l'appareil est agrandi",
     "Visibility of background from BACKGROUND_VIEW/URL/HTML, if device is enlarged": "Visibilité de l'arrière-plan à partir de BACKGROUND_URL / HTML, si l'appareil est agrandi",
     "Visible": "Visible",
-    "Volume": "Le Volume",
+    "Volume": "Le volume",
     "Vorraum": "Vestibule",
     "WC EG": "WC 1er étage",
     "WC OG": "WC 2ème étage",

--- a/www/i18n/fr/translations.json
+++ b/www/i18n/fr/translations.json
@@ -1288,7 +1288,7 @@
     "Visibility of background from BACKGROUND_URL/HTML, if device is enlarged": "Visibilité de l'arrière-plan à partir de BACKGROUND_URL / HTML, si l'appareil est agrandi",
     "Visibility of background from BACKGROUND_VIEW/URL/HTML, if device is enlarged": "Visibilité de l'arrière-plan à partir de BACKGROUND_URL / HTML, si l'appareil est agrandi",
     "Visible": "Visible",
-    "Volume": "Le volume",
+    "Volume": "Le Volume",
     "Vorraum": "Vestibule",
     "WC EG": "WC 1er étage",
     "WC OG": "WC 2ème étage",


### PR DESCRIPTION
Translations update from [ioBroker Translation System](https://weblate.iobroker.net) for [ioBroker Adapters/iqontrol](https://weblate.iobroker.net/projects/adapters/iqontrol/).


It also includes following components:

* [ioBroker Adapters/iqontrol-web](https://weblate.iobroker.net/projects/adapters/iqontrol-web/)



Current translation status:

![Weblate translation status](https://weblate.iobroker.net/widgets/adapters/-/iqontrol/horizontal-auto.svg)